### PR TITLE
  GIVE UP to implement of multple selection for macOS

### DIFF
--- a/Shared/Components/GridItemCount.swift
+++ b/Shared/Components/GridItemCount.swift
@@ -9,15 +9,13 @@ func gridItems() -> [GridItem] {
     .init(.flexible(), spacing: 1),
   ]
   #elseif os(macOS)
-  guard let mainScreen = NSScreen.main else {
-    return [
-      .init(.flexible(), spacing: 1),
-      .init(.flexible(), spacing: 1),
-      .init(.flexible(), spacing: 1),
-    ]
-  }
-  return (0..<Int(floor(mainScreen.frame.width / 200))).map { _ in
-      .init(.flexible(minimum: 200), spacing: 1)
-  }
-  #endif
+  [
+    .init(.flexible(), spacing: 1),
+    .init(.flexible(), spacing: 1),
+    .init(.flexible(), spacing: 1),
+    .init(.flexible(), spacing: 1),
+    .init(.flexible(), spacing: 1),
+  ]
+}
+#endif
 }

--- a/Shared/Components/GridItemCount.swift
+++ b/Shared/Components/GridItemCount.swift
@@ -16,6 +16,5 @@ func gridItems() -> [GridItem] {
     .init(.flexible(), spacing: 1),
     .init(.flexible(), spacing: 1),
   ]
-}
 #endif
 }

--- a/macOS/TagList/TagList.swift
+++ b/macOS/TagList/TagList.swift
@@ -65,8 +65,9 @@ struct TagList: View {
         } label: {
           Text(tag.name)
         }
+        .buttonStyle(.plain)
+        .tag(tag.id)
       }
-      .buttonStyle(.plain)
     }
     .padding(.top, 20)
   }

--- a/macOS/TagList/TagList.swift
+++ b/macOS/TagList/TagList.swift
@@ -35,41 +35,50 @@ struct TagList: View {
   }
 
   var body: some View {
-    ZStack {
-      NavigationLink(
-        isActive: .constant(true), destination: {
-          PhotoAssetListPage(selectedTags: selectedElements.compactMap(mappedTag))
-            .environment(\.managedObjectContext, viewContext)
-        },
-        label: {
-          EmptyView()
-        }
-      )
+    GeometryReader { geometry in
+      let width = geometry.size.width
 
-
-      List(allElements, id: \.self, selection: $selectedElements) { tag in
-        Button {
-          if tag == .all {
-            selectedElements = [.all]
-          } else {
-            if let allIndex = selectedElements.firstIndex(of: .all) {
-              selectedElements.remove(at: allIndex)
-            }
-
-            if let index = selectedElements.firstIndex(of: tag) {
-              selectedElements.remove(at: index)
-            } else {
-              selectedElements.insert(tag)
-            }
+      ZStack {
+        NavigationLink(
+          isActive: .constant(true), destination: {
+            PhotoAssetListPage(selectedTags: selectedElements.compactMap(mappedTag))
+              .environment(\.managedObjectContext, viewContext)
+          },
+          label: {
+            EmptyView()
           }
-        } label: {
-          Text(tag.name)
+        )
+
+
+        List(allElements, id: \.self, selection: $selectedElements) { tag in
+          Button {
+            if tag == .all {
+              selectedElements = [.all]
+            } else {
+              if let allIndex = selectedElements.firstIndex(of: .all) {
+                selectedElements.remove(at: allIndex)
+              }
+
+              if let index = selectedElements.firstIndex(of: tag) {
+                selectedElements.remove(at: index)
+              } else {
+                selectedElements.insert(tag)
+              }
+            }
+          } label: {
+            Text(tag.name)
+              .frame(width: width)
+              .border(Color.red)
+              .onAppear {
+                print("[DEBUG] width: ", width)
+              }
+          }
+          .buttonStyle(.plain)
+          .tag(tag.id)
         }
-        .buttonStyle(.plain)
-        .tag(tag.id)
       }
+      .padding(.top, 20)
     }
-    .padding(.top, 20)
   }
 
   private var allElements: [ListElement] {

--- a/macOS/TagList/TagList.swift
+++ b/macOS/TagList/TagList.swift
@@ -7,7 +7,7 @@ struct TagList: View {
     animation: .default)
   var tags: FetchedResults<Tag>
 
-  @State var selectedElements: Set<ListElement> = [.all]
+  @State var selectedElement: ListElement = .all
 
   enum ListElement: Identifiable, Hashable {
     case all
@@ -38,7 +38,7 @@ struct TagList: View {
     ZStack {
       NavigationLink(
         isActive: .constant(true), destination: {
-          PhotoAssetListPage(selectedTags: selectedElements.compactMap(mappedTag))
+          PhotoAssetListPage(selectedTags: [mappedTag(selectedElement)].compactMap { $0 })
             .environment(\.managedObjectContext, viewContext)
         },
         label: {
@@ -47,19 +47,19 @@ struct TagList: View {
       )
 
 
-      List(allElements, id: \.self, selection: $selectedElements) { tag in
+      List(allElements, id: \.self) { tag in
         Button {
           if tag == .all {
-            selectedElements = [.all]
+            selectedElement = .all
           } else {
-            if let allIndex = selectedElements.firstIndex(of: .all) {
-              selectedElements.remove(at: allIndex)
+            if selectedElement == .all {
+              selectedElement = .all
             }
 
-            if let index = selectedElements.firstIndex(of: tag) {
-              selectedElements.remove(at: index)
+            if selectedElement == tag {
+              selectedElement = .all
             } else {
-              selectedElements.insert(tag)
+              selectedElement = tag
             }
           }
         } label: {

--- a/macOS/TagList/TagList.swift
+++ b/macOS/TagList/TagList.swift
@@ -35,50 +35,41 @@ struct TagList: View {
   }
 
   var body: some View {
-    GeometryReader { geometry in
-      let width = geometry.size.width
-
-      ZStack {
-        NavigationLink(
-          isActive: .constant(true), destination: {
-            PhotoAssetListPage(selectedTags: selectedElements.compactMap(mappedTag))
-              .environment(\.managedObjectContext, viewContext)
-          },
-          label: {
-            EmptyView()
-          }
-        )
-
-
-        List(allElements, id: \.self, selection: $selectedElements) { tag in
-          Button {
-            if tag == .all {
-              selectedElements = [.all]
-            } else {
-              if let allIndex = selectedElements.firstIndex(of: .all) {
-                selectedElements.remove(at: allIndex)
-              }
-
-              if let index = selectedElements.firstIndex(of: tag) {
-                selectedElements.remove(at: index)
-              } else {
-                selectedElements.insert(tag)
-              }
-            }
-          } label: {
-            Text(tag.name)
-              .frame(width: width)
-              .border(Color.red)
-              .onAppear {
-                print("[DEBUG] width: ", width)
-              }
-          }
-          .buttonStyle(.plain)
-          .tag(tag.id)
+    ZStack {
+      NavigationLink(
+        isActive: .constant(true), destination: {
+          PhotoAssetListPage(selectedTags: selectedElements.compactMap(mappedTag))
+            .environment(\.managedObjectContext, viewContext)
+        },
+        label: {
+          EmptyView()
         }
+      )
+
+
+      List(allElements, id: \.self, selection: $selectedElements) { tag in
+        Button {
+          if tag == .all {
+            selectedElements = [.all]
+          } else {
+            if let allIndex = selectedElements.firstIndex(of: .all) {
+              selectedElements.remove(at: allIndex)
+            }
+
+            if let index = selectedElements.firstIndex(of: tag) {
+              selectedElements.remove(at: index)
+            } else {
+              selectedElements.insert(tag)
+            }
+          }
+        } label: {
+          Text(tag.name)
+        }
+        .buttonStyle(.plain)
+        .tag(tag.id)
       }
-      .padding(.top, 20)
     }
+    .padding(.top, 20)
   }
 
   private var allElements: [ListElement] {


### PR DESCRIPTION

  ## Abstract
  macOSでのタグの複数選択のサポートを一旦やめた

  ## Why
  以下の構文でListでのmultipleSelection はできるのだが、Textの表示領域の中でも文字部分をタップしないと複数選択が有効にならないので辞めた。余白部分をタップすると今度はListが本  来持っている選択処理が実行され、 `Binding selectedElements` がクリアされ、かつどこも選ばれていない状態になったりして体験がややこしすぎるのでやめる

  なお、Text 部分を HStack { Text() Spacer() } や Text().frame(width:) や Text().onTapGesture { } を試したがどれも同じ結果になったのでおそらく回避方法はない

  ```swift
        List(allElements, id: \.self, selection: $selectedElements) { tag in
          Button {
            if tag == .all {
              selectedElements = [.all]
            } else {
              if let allIndex = selectedElements.firstIndex(of: .all) {
                selectedElements.remove(at: allIndex)
              }

              if let index = selectedElements.firstIndex(of: tag) {
                selectedElements.remove(at: index)
              } else {
                selectedElements.insert(tag)
              }
            }
          } label: {
            Text(tag.name)
          }
          .buttonStyle(.plain)
          .tag(tag.id)
        }
      }

  ```
